### PR TITLE
Fix getting of non-relative search result DN

### DIFF
--- a/src/main/java/org/identityconnectors/ldap/ADLdapUtil.java
+++ b/src/main/java/org/identityconnectors/ldap/ADLdapUtil.java
@@ -83,26 +83,26 @@ public class ADLdapUtil {
 
         StringBuilder sGUID = new StringBuilder(43);
         sGUID.append("<GUID=");
-        sGUID.append(AddLeadingZero((int)GUID[3] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[2] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[1] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[0] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[3] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[2] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[1] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[0] & 0xFF));
         sGUID.append("-");
-        sGUID.append(AddLeadingZero((int)GUID[5] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[4] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[5] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[4] & 0xFF));
         sGUID.append("-");
-        sGUID.append(AddLeadingZero((int)GUID[7] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[6] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[7] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[6] & 0xFF));
         sGUID.append("-");
-        sGUID.append(AddLeadingZero((int)GUID[8] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[9] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[8] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[9] & 0xFF));
         sGUID.append("-");
-        sGUID.append(AddLeadingZero((int)GUID[10] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[11] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[12] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[13] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[14] & 0xFF));
-        sGUID.append(AddLeadingZero((int)GUID[15] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[10] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[11] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[12] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[13] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[14] & 0xFF));
+        sGUID.append(AddLeadingZero(GUID[15] & 0xFF));
         sGUID.append(">");
 
         return sGUID.toString();
@@ -123,7 +123,7 @@ public class ADLdapUtil {
         StringBuilder sGUID = new StringBuilder(39);
         sGUID.append("<GUID=");
         for(int i=0;i<16;i++){
-            sGUID.append(AddLeadingZero((int)GUID[i] & 0xFF));
+            sGUID.append(AddLeadingZero(GUID[i] & 0xFF));
         }
         sGUID.append(">");
         return sGUID.toString();
@@ -215,7 +215,7 @@ public class ADLdapUtil {
         // bytes[2..7] : the Authority
         StringBuilder tmpBuff = new StringBuilder();
         for (int t = 2; t <= 7; t++) {
-            tmpBuff.append(AddLeadingZero((int) SID[t] & 0xFF));
+            tmpBuff.append(AddLeadingZero(SID[t] & 0xFF));
         }
         strSID.append(Long.parseLong(tmpBuff.toString(), 16));
 
@@ -256,7 +256,7 @@ public class ADLdapUtil {
     }
 
     public static List<Object> fetchGroupMembersByRange(LdapConnection conn, SearchResult result){
-        return fetchGroupMembersByRange(conn, LdapEntry.create(null, result));
+        return fetchGroupMembersByRange(conn, LdapEntry.create(result));
     }
 
     /*
@@ -284,10 +284,10 @@ public class ADLdapUtil {
                     NamingEnumeration<SearchResult> entries = context.search(entry.getDN(), "objectclass=*", controls);
                     SearchResult res = entries.next();
                     if (res != null) {
-                        range = conn.getSchemaMapping().createAttribute(ObjectClass.GROUP, String.format("member;range=%d-%d", first, last), LdapEntry.create(null,res), true);
+                        range = conn.getSchemaMapping().createAttribute(ObjectClass.GROUP, String.format("member;range=%d-%d", first, last), LdapEntry.create(res), true);
                         // we hit the last slice... so the range ends with an '*'
                         if (range.getValue().isEmpty()) {
-                            range = conn.getSchemaMapping().createAttribute(ObjectClass.GROUP, String.format("member;range=%d-*", first), LdapEntry.create(null,res), true);
+                            range = conn.getSchemaMapping().createAttribute(ObjectClass.GROUP, String.format("member;range=%d-*", first), LdapEntry.create(res), true);
                             done = true;
                         }
                         members.addAll(range.getValue());

--- a/src/main/java/org/identityconnectors/ldap/GroupHelper.java
+++ b/src/main/java/org/identityconnectors/ldap/GroupHelper.java
@@ -233,10 +233,12 @@ public class GroupHelper {
             return groupDN;
         }
 
+        @Override
         public int hashCode() {
             return memberRef.hashCode() ^ groupDN.hashCode();
         }
 
+        @Override
         public boolean equals(Object o) {
             if (o instanceof GroupMembership) {
                 GroupMembership that = (GroupMembership)o;
@@ -319,8 +321,9 @@ public class GroupHelper {
 
         private final List<String> results = new ArrayList<String>();
 
+        @Override
         public boolean handle(String baseDN, SearchResult searchResult) throws NamingException {
-            results.add(LdapEntry.create(baseDN, searchResult).getDN().toString());
+            results.add(LdapEntry.create(searchResult).getDN().toString());
             return true;
         }
 
@@ -341,8 +344,9 @@ public class GroupHelper {
             this.memberRef = memberRef;
         }
 
+        @Override
         public boolean handle(String baseDN, SearchResult searchResult) throws NamingException {
-            LdapName groupDN = LdapEntry.create(baseDN, searchResult).getDN();
+            LdapName groupDN = LdapEntry.create(searchResult).getDN();
             results.add(new GroupMembership(memberRef, groupDN.toString()));
             return true;
         }

--- a/src/main/java/org/identityconnectors/ldap/LdapEntry.java
+++ b/src/main/java/org/identityconnectors/ldap/LdapEntry.java
@@ -19,6 +19,8 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ *
+ * Portions Copyright 2025 Wren Security.
  */
 package org.identityconnectors.ldap;
 
@@ -124,32 +126,11 @@ public abstract class LdapEntry {
         @Override
         public LdapName getDN() {
             if (dn == null) {
-                if (result.isRelative()) {
-                    try {
-                        //dn = join(result.getName(), baseDN);
-                        dn = new LdapName(result.getNameInNamespace());
-                    } catch (InvalidNameException ex) {
-                         throw new ConnectorException(ex);
-                    }
-                } else {
-                    // Striping the scheme and host, according to a comment in the adapter.
-                    dn = join(getDNFromLdapUrl(result.getName()), null);
-                }
+                dn = quietCreateLdapName(result.getNameInNamespace());
             }
             return dn;
         }
 
-        private String getDNFromLdapUrl(String url) {
-            int schemeEndPos = url.indexOf("://");
-            if (schemeEndPos < 0) {
-                return null;
-            }
-            int slashAfterHostPos = url.indexOf('/', schemeEndPos + 3);
-            if (slashAfterHostPos < 0) {
-                return null;
-            }
-            return url.substring(slashAfterHostPos + 1);
-        }
     }
 
     private static final class Simple extends LdapEntry {

--- a/src/main/java/org/identityconnectors/ldap/LdapEntry.java
+++ b/src/main/java/org/identityconnectors/ldap/LdapEntry.java
@@ -54,8 +54,8 @@ public abstract class LdapEntry {
         ENTRY_DN_ATTRS = unmodifiableSet(set);
     }
 
-    public static LdapEntry create(String baseDN, SearchResult result) {
-        return new SearchResultBased(baseDN, result);
+    public static LdapEntry create(SearchResult result) {
+        return new SearchResultBased(result);
     }
 
     public static LdapEntry create(String entryDN, Attributes attributes) {
@@ -102,16 +102,14 @@ public abstract class LdapEntry {
 
     private static final class SearchResultBased extends LdapEntry {
 
-        private final String baseDN;
         private final SearchResult result;
 
         private Attributes attributes;
         private LdapName dn;
 
-        public SearchResultBased(String baseDN, SearchResult result) {
+        public SearchResultBased(SearchResult result) {
             assert result != null;
 
-            this.baseDN = baseDN;
             this.result = result;
         }
 

--- a/src/main/java/org/identityconnectors/ldap/search/LdapSearch.java
+++ b/src/main/java/org/identityconnectors/ldap/search/LdapSearch.java
@@ -139,6 +139,7 @@ public class LdapSearch {
         final Set<String> attrsToGet = getAttributesToGet(attrsToGetOption);
         LdapInternalSearch search = getInternalSearch(attrsToGet);
         search.execute(new LdapSearchResultsHandler() {
+            @Override
             public boolean handle(String baseDN, SearchResult result) throws NamingException {
                 return handler.handle(createConnectorObject(baseDN, result, attrsToGet, attrsToGetOption != null));
             }
@@ -155,6 +156,7 @@ public class LdapSearch {
         final ConnectorObject[] results = new ConnectorObject[]{null};
         LdapInternalSearch search = getInternalSearch(attrsToGet);
         search.execute(new LdapSearchResultsHandler() {
+            @Override
             public boolean handle(String baseDN, SearchResult result) throws NamingException {
                 results[0] = createConnectorObject(baseDN, result, attrsToGet, attrsToGetOption != null);
                 return false;
@@ -232,7 +234,7 @@ public class LdapSearch {
      * is used to compute the connector object's name attribute.
      */
     private ConnectorObject createConnectorObject(String baseDN, SearchResult result, Set<String> attrsToGet, boolean emptyAttrWhenNotFound) {
-        LdapEntry entry = LdapEntry.create(baseDN, result);
+        LdapEntry entry = LdapEntry.create(result);
 
         ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
         builder.setObjectClass(oclass);

--- a/src/main/java/org/identityconnectors/ldap/search/LdapSearches.java
+++ b/src/main/java/org/identityconnectors/ldap/search/LdapSearches.java
@@ -136,6 +136,7 @@ public class LdapSearches {
 
         LdapSearch search = new LdapSearch(conn, oclass, ldapFilter, null, builder.build(), baseDN);
         search.execute(new ResultsHandler() {
+            @Override
             public boolean handle(ConnectorObject object) {
                 result.add(object);
                 return true;
@@ -167,8 +168,9 @@ public class LdapSearches {
         controls.setReturningAttributes(ldapAttrsToGet);
         LdapInternalSearch search = new LdapInternalSearch(conn, null, singletonList(entryDN.toString()), new DefaultSearchStrategy(true), controls);
         search.execute(new LdapSearchResultsHandler() {
+            @Override
             public boolean handle(String baseDN, SearchResult searchResult) {
-                result.add(LdapEntry.create(baseDN, searchResult));
+                result.add(LdapEntry.create(searchResult));
                 return false;
             }
         });

--- a/src/main/java/org/identityconnectors/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
+++ b/src/main/java/org/identityconnectors/ldap/sync/sunds/SunDSChangeLogSyncStrategy.java
@@ -126,10 +126,12 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
         this.oclass = oclass;
     }
 
+    @Override
     public SyncToken getLatestSyncToken() {
         return new SyncToken(getChangeLogAttributes().getLastChangeNumber());
     }
 
+    @Override
     public void sync(SyncToken token, final SyncResultsHandler handler, final OperationOptions options) {
         String context = getChangeLogAttributes().getChangeLogContext();
         final String changeNumberAttr = getChangeNumberAttribute();
@@ -148,9 +150,10 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
             LdapInternalSearch search = new LdapInternalSearch(conn, filter, singletonList(context), new DefaultSearchStrategy(false), controls);
 
             search.execute(new LdapSearchResultsHandler() {
+                @Override
                 public boolean handle(String baseDN, SearchResult result) throws NamingException {
                     results[0] = true;
-                    LdapEntry entry = LdapEntry.create(baseDN, result);
+                    LdapEntry entry = LdapEntry.create(result);
 
                     int changeNumber = convertToInt(getStringAttrValue(entry.getAttributes(), changeNumberAttr), -1);
                     if (changeNumber > currentChangeNumber[0]) {
@@ -450,7 +453,7 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
                 String resetPolicy = conn.getConfiguration().getResetSyncToken();
                 // The current SyncToken should never be greater than the lastChangeNumber in the changelog
                 // We use the value defined by resetSyncToken to act
-                log.info("The current SyncToken value ({0}) is greater than the lastChangeNumber value ({1})", (Integer) lastToken.getValue(), getChangeLogAttributes().getLastChangeNumber());
+                log.info("The current SyncToken value ({0}) is greater than the lastChangeNumber value ({1})", lastToken.getValue(), getChangeLogAttributes().getLastChangeNumber());
                 if (RESET_SYNC_TOKEN_NEVER.equalsIgnoreCase(resetPolicy)){
                     // do nothing
                     lastTokenValue++;
@@ -661,8 +664,10 @@ public class SunDSChangeLogSyncStrategy implements LdapSyncStrategy {
     private PasswordDecryptor getPasswordDecryptor() {
         if (passwordDecryptor == null) {
             conn.getConfiguration().getPasswordDecryptionKey().access(new Accessor() {
+                @Override
                 public void access(final byte[] decryptionKey) {
                     conn.getConfiguration().getPasswordDecryptionInitializationVector().access(new Accessor() {
+                        @Override
                         public void access(byte[] decryptionIV) {
                             passwordDecryptor = new PasswordDecryptor(decryptionKey, decryptionIV);
                         }

--- a/src/main/java/org/identityconnectors/ldap/sync/timestamps/TimestampsSyncStrategy.java
+++ b/src/main/java/org/identityconnectors/ldap/sync/timestamps/TimestampsSyncStrategy.java
@@ -93,10 +93,12 @@ public class TimestampsSyncStrategy implements LdapSyncStrategy {
         this.server = conn.getServerType();
     }
 
+    @Override
     public SyncToken getLatestSyncToken() {
         return new SyncToken(getNowTime());
     }
 
+    @Override
     public void sync(SyncToken token, final SyncResultsHandler handler, final OperationOptions options) {
         // ldapsearch -h host -p 389 -b "dc=example,dc=com" -D "cn=administrator,cn=users,dc=example,dc=com" -w xxx "whenchanged>=20130214130642.0Z"
         // on AD
@@ -135,8 +137,9 @@ public class TimestampsSyncStrategy implements LdapSyncStrategy {
 
         try {
             search.execute(new LdapSearchResultsHandler() {
+                @Override
                 public boolean handle(String baseDN, SearchResult result) throws NamingException {
-                    LdapEntry entry = LdapEntry.create(baseDN, result);
+                    LdapEntry entry = LdapEntry.create(result);
                     Attributes attrs = result.getAttributes();
                     Uid uid = conn.getSchemaMapping().createUid(oclass, entry);
                     // build the object first

--- a/src/test/java/org/identityconnectors/ldap/SunDSTestBase.java
+++ b/src/test/java/org/identityconnectors/ldap/SunDSTestBase.java
@@ -68,8 +68,9 @@ public class SunDSTestBase {
                 new DefaultSearchStrategy(false), controls);
         final List<LdapName> entryDNs = new ArrayList<LdapName>();
         search.execute(new LdapSearchResultsHandler() {
+            @Override
             public boolean handle(String baseDN, SearchResult result) throws NamingException {
-                entryDNs.add(LdapEntry.create(baseDN, result).getDN());
+                entryDNs.add(LdapEntry.create(result).getDN());
                 return true;
             }
         });


### PR DESCRIPTION
This PR adds the ability to decode the DN value of a search result when it is derived from an LDAP URL. The source value is encoded in [LdapSearchEnumeration.java#L89](https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSearchEnumeration.java#L89) and [LdapURL.java#L182](https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/java.naming/share/classes/com/sun/jndi/ldap/LdapURL.java#L182).